### PR TITLE
Bump theme version & move About/Membership to footer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "jekyll"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
-gem "jekyll-theme-open-project"
 # gem "jekyll-theme-open-project", path: "~/src/jekyll-theme-open-project"
+gem "jekyll-theme-open-project", "~> 2.1.11"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,10 @@ theme: jekyll-theme-open-project
 
 includes_dir: .
 
+extra_footer_links:
+  - { url: "/about/", title: "About ELF" }
+  - { url: "/membership/", title: "Membership" }
+
 social:
   links:
     - https://github.com/expresslang

--- a/nav-links.html
+++ b/nav-links.html
@@ -4,11 +4,7 @@
   <input type="search" id="siteSearchInput" placeholder="Type to search…">
 </div> -->
 
-{% include nav-page-link.html htmlclass="about" url="/about/" title="About" active_for_nested=true %}
-
 {% include nav-page-link.html htmlclass="blog" url="/blog/" title="Blog" active_for_nested=true %}
-
-{% include nav-page-link.html htmlclass="membership" url="/membership/" title="Membership" active_for_nested=true %}
 
 {% include project-nav.html %}
 


### PR DESCRIPTION
This addresses the issue where top navigation is cut off. The links moved make sense for footer navigation.
Some other links can be further collapsed (e.g., Learn and References should not have their top links, they should be under Documentation but landing page can/should offer a shortcut in the form of a call-to-action button).

Theme version bump is required, new version was released to support extra footer links.