### PR TITLE
fix: update CAx Implementor Forum URL to mbx-if.org

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -44,7 +44,7 @@ jobs:
           --max-cache-age 1d
           --accept 200,202,206,403,429
           --exclude https://www.expresslang.org
-          --exclude https://www.cax-if.org
+          --exclude https://www.mbx-if.org
           --base http://localhost:3000
           'dist/**/*.html'
         fail: true

--- a/content/course/01-intro-iso-10303.adoc
+++ b/content/course/01-intro-iso-10303.adoc
@@ -171,4 +171,4 @@ This layered approach ensures that product data is both human-understandable (th
 
 == Implementation Support
 
-The CAx Implementor Forum (https://www.cax-if.org) provides implementation support and conformance testing for STEP application protocols, helping organizations deploy STEP-based data exchange with confidence.
+The CAx Implementor Forum (https://www.mbx-if.org/home/) provides implementation support and conformance testing for STEP application protocols, helping organizations deploy STEP-based data exchange with confidence.


### PR DESCRIPTION
The CAx Implementor Forum has moved from `cax-if.org` to `mbx-if.org/home/`.

Updates the link in the Jotne course content and the lychee exclusion in CI.

Closes #33