### PR TITLE
feat: address open GitHub issues

### DIFF
--- a/content/languages/express.adoc
+++ b/content/languages/express.adoc
@@ -21,6 +21,153 @@ Unlike general-purpose programming languages, EXPRESS is purpose-built for defin
 * *ENUMERATION and SELECT types* — extensible type definitions
 * *Schema partitioning* — modular organization of large information models
 
+[[building-blocks]]
+== Building blocks
+
+An EXPRESS schema is composed of several fundamental building blocks that work together to define an information model.
+
+[[datatypes]]
+=== Datatypes
+
+EXPRESS provides a layered type system built on a set of simple (atomic) datatypes:
+
+* *NUMBER* — abstract numeric type (INTEGER or REAL)
+* *INTEGER* — whole numbers
+* *REAL* — floating-point numbers
+* *STRING* — character sequences
+* *BOOLEAN* — TRUE or FALSE
+* *LOGICAL* — TRUE, FALSE, or UNKNOWN
+* *BINARY* — bit sequences
+
+On top of these, EXPRESS provides aggregation types:
+
+* *ARRAY* — fixed-size, ordered collection with optional uniqueness constraint
+* *LIST* — variable-size, ordered collection
+* *SET* — variable-size, unordered collection with uniqueness constraint
+* *BAG* — variable-size, unordered collection (duplicates allowed)
+
+.User-defined types
+[source,express]
+----
+TYPE mass = REAL;
+END_TYPE;
+
+TYPE colour = ENUMERATION OF (red, green, blue);
+END_TYPE;
+
+TYPE shape = SELECT (box, cylinder, sphere);
+END_TYPE;
+----
+
+[[entity-attributes]]
+=== Entity attributes
+
+Entities are the core modelling construct in EXPRESS. Each entity declares a set of attributes that define the properties of the object being modelled.
+
+[source,express]
+----
+ENTITY person;
+  name : STRING;
+  birth_date : date;
+  height : OPTIONAL REAL;
+DERIVE
+  age : INTEGER := years_since(birth_date);
+INVERSE
+  employer : SET[0:?] OF employment FOR employee;
+END_ENTITY;
+----
+
+Attributes can be:
+
+* *Explicit* — mandatory or OPTIONAL values provided directly
+* *Derived* (DERIVE) — computed from other attributes using expressions
+* *Inverse* (INVERSE) — bidirectional relationships maintained automatically
+
+[[supertypes-and-subtypes]]
+=== Supertypes and subtypes
+
+EXPRESS supports single and multiple inheritance through supertype/subtype relationships. Subtypes inherit all attributes of their supertypes and may add new attributes and constraints.
+
+[source,express]
+----
+ENTITY vehicle;
+  registration : STRING;
+END_ENTITY;
+
+ENTITY car
+  SUBTYPE OF (vehicle);
+  no_of_doors : INTEGER;
+END_ENTITY;
+
+ENTITY truck
+  SUBTYPE OF (vehicle);
+  payload : mass;
+END_ENTITY;
+----
+
+Complex supertype constraints control which combinations of subtypes are valid:
+
+* *ONEOF* — exactly one subtype must be instantiated
+* *ANDOR* — any combination of subtypes may coexist
+* *AND* — all listed subtypes must coexist
+
+[[constraints-and-rules]]
+=== Constraints and rules
+
+EXPRESS provides three levels of constraint specification:
+
+.WHERE rules (local constraints)
+[source,express]
+----
+ENTITY positive_integer;
+  value : INTEGER;
+WHERE
+  is_positive : value > 0;
+END_ENTITY;
+----
+
+.GLOBAL rules (schema-level constraints)
+[source,express]
+----
+RULE unique_registration FOR (vehicle);
+  LOCAL
+    regs : SET OF STRING := [];
+  END_LOCAL;
+  WHERE
+    no_duplicates : SIZEOF(regs - QUERY(v <* vehicle | v.registration IN regs)) = 0;
+END_RULE;
+----
+
+.UNIQUE constraints
+[source,express]
+----
+ENTITY employee;
+  employee_id : STRING;
+  social_security : STRING;
+UNIQUE
+  id_unique : employee_id;
+  ss_unique : social_security;
+END_ENTITY;
+----
+
+[[functions-and-procedures]]
+=== Functions and procedures
+
+EXPRESS includes algorithmic constructs for constraint evaluation and data manipulation:
+
+[source,express]
+----
+FUNCTION distance(p1 : point; p2 : point) : REAL;
+  LOCAL
+    dx, dy, dz : REAL;
+  END_LOCAL;
+  dx := p1.x - p2.x;
+  dy := p1.y - p2.y;
+  dz := p1.z - p2.z;
+  RETURN (SQRT(dx*dx + dy*dy + dz*dz));
+END_FUNCTION;
+----
+
 [[syntax]]
 == Syntax
 
@@ -32,16 +179,40 @@ EXPRESS uses a Pascal-like lexical syntax. A schema definition typically include
 * `FUNCTION` and `PROCEDURE` for reusable algorithmic logic
 * `RULE` declarations for global constraints
 
-.Example entity declaration
+.Complete schema example
 [source,express]
 ----
-ENTITY point
+SCHEMA Geometry;
+
+TYPE point_list = LIST[2:?] OF point;
+END_TYPE;
+
+ENTITY point;
   x : REAL;
   y : REAL;
   z : REAL;
 WHERE
   not_at_origin : (x <> 0.0) OR (y <> 0.0) OR (z <> 0.0);
 END_ENTITY;
+
+ENTITY line;
+  start : point;
+  end : point;
+WHERE
+  not_zero_length : distance(start, end) > 0.0;
+END_ENTITY;
+
+FUNCTION distance(p1 : point; p2 : point) : REAL;
+  LOCAL
+    dx, dy, dz : REAL;
+  END_LOCAL;
+  dx := p1.x - p2.x;
+  dy := p1.y - p2.y;
+  dz := p1.z - p2.z;
+  RETURN (SQRT(dx*dx + dy*dy + dz*dz));
+END_FUNCTION;
+
+END_SCHEMA;
 ----
 
 [[history]]

--- a/content/learn/example-exp-cars.adoc
+++ b/content/learn/example-exp-cars.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = EXPRESS example model Car Registration Authority

--- a/content/learn/example-expg-cars.adoc
+++ b/content/learn/example-expg-cars.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = EXPRESS-G example model Car Registration Authority

--- a/content/learn/example-model-carreg.adoc
+++ b/content/learn/example-model-carreg.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Example model statement Car Registration Authority

--- a/content/learn/express-01-what-is-information.adoc
+++ b/content/learn/express-01-what-is-information.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = What is Information Modelling?

--- a/content/learn/express-02-background.adoc
+++ b/content/learn/express-02-background.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Background on EXPRESS

--- a/content/learn/express-03-step-overview.adoc
+++ b/content/learn/express-03-step-overview.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = The EXPRESS Language and STEP

--- a/content/learn/express-04-basic-syntax.adoc
+++ b/content/learn/express-04-basic-syntax.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Basic EXPRESS Syntax

--- a/content/learn/express-advanced-01-extensibles.adoc
+++ b/content/learn/express-advanced-01-extensibles.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Extensibles and Relationships

--- a/content/learn/express-advanced-02-subtyping.adoc
+++ b/content/learn/express-advanced-02-subtyping.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Subtypes and Supertypes

--- a/content/learn/express-advanced-03-global-constraints.adoc
+++ b/content/learn/express-advanced-03-global-constraints.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Global Constraints and Schemas

--- a/content/learn/express-g.adoc
+++ b/content/learn/express-g.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Introducing EXPRESS-G

--- a/content/learn/express-rules-01-principles.adoc
+++ b/content/learn/express-rules-01-principles.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Rule Principles

--- a/content/learn/express-rules-02-local-global.adoc
+++ b/content/learn/express-rules-02-local-global.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Local and Global Rules

--- a/content/learn/express-rules-03-recursion.adoc
+++ b/content/learn/express-rules-03-recursion.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Recursion in EXPRESS

--- a/content/learn/express-rules-04-builtins.adoc
+++ b/content/learn/express-rules-04-builtins.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Built-in Functions for Rules

--- a/content/learn/modelling-answers.adoc
+++ b/content/learn/modelling-answers.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Modeling Exercises -- Some Answers

--- a/content/learn/modelling-best-practices.adoc
+++ b/content/learn/modelling-best-practices.adoc
@@ -1,9 +1,9 @@
 ---
-layout: author-docs
+title: EXPRESS modelling best practices
 ---
 :stem:
 
-= EXPRESS modelling best practices
+== Introduction
 
 == Introduction
 

--- a/content/learn/modelling-exercises.adoc
+++ b/content/learn/modelling-exercises.adoc
@@ -1,6 +1,3 @@
----
-layout: author-docs
----
 :stem:
 
 = Modeling exercises

--- a/content/pages/about.adoc
+++ b/content/pages/about.adoc
@@ -1,9 +1,6 @@
 ---
-layout: docs-base
-html-class: docs-page
 title: About the EXPRESS Language Foundation
 ---
-:page-liquid:
 
 == Our mission
 

--- a/content/pages/language.adoc
+++ b/content/pages/language.adoc
@@ -1,9 +1,6 @@
 ---
-layout: docs-base
-html-class: docs-page
 title: Introducing the EXPRESS language family
 ---
-:page-liquid:
 
 == Purpose
 

--- a/content/pages/membership.adoc
+++ b/content/pages/membership.adoc
@@ -1,6 +1,4 @@
 ---
-layout: docs-base
-html-class: docs-page
 title: Membership
 ---
 

--- a/content/pages/privacy.adoc
+++ b/content/pages/privacy.adoc
@@ -1,6 +1,4 @@
 ---
-layout: docs-base
-html-class: docs-page
 title: Privacy policy
 ---
 == Privacy policy

--- a/content/pages/references.adoc
+++ b/content/pages/references.adoc
@@ -1,9 +1,6 @@
 ---
-layout: docs-base
-html-class: docs-page
 title: EXPRESS language references
 ---
-:page-liquid:
 
 == EXPRESS grammar in BNF form
 

--- a/content/pages/tos.adoc
+++ b/content/pages/tos.adoc
@@ -1,6 +1,4 @@
 ---
-layout: docs-base
-html-class: docs-page
 title: Terms of service
 ---
 == Terms of service

--- a/content/posts/2022-03-18-elf-launch.adoc
+++ b/content/posts/2022-03-18-elf-launch.adoc
@@ -1,5 +1,4 @@
 ---
-layout: post
 title: "Introducing the EXPRESS Language Foundation"
 date: 2022-03-18
 categories: announcements

--- a/content/posts/2022-05-01-express-history.adoc
+++ b/content/posts/2022-05-01-express-history.adoc
@@ -1,5 +1,4 @@
 ---
-layout: post
 title: A history of the EXPRESS languages
 date: 2022-05-01
 categories: announcements

--- a/content/posts/2022-06-21-elf-joins-metaverse-standards-forum.adoc
+++ b/content/posts/2022-06-21-elf-joins-metaverse-standards-forum.adoc
@@ -1,5 +1,4 @@
 ---
-layout: post
 title: EXPRESS Language Foundation joins the Metaverse Standards Forum as Principal
 date: 2022-06-21
 categories: announcements

--- a/content/posts/2023-08-17-douglas-schenck-on-express.adoc
+++ b/content/posts/2023-08-17-douglas-schenck-on-express.adoc
@@ -1,5 +1,4 @@
 ---
-layout: post
 title: Thoughts on EXPRESS
 date: 2023-08-17
 categories: announcements

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <script>
       // Prevent FOUC for dark mode
       (function(){

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -132,9 +132,12 @@ const milestones = [
       <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-20 lg:pt-28 lg:pb-28">
         <div class="flex flex-col lg:flex-row items-start gap-12 lg:gap-16">
           <div class="max-w-xl flex-1 min-w-0">
-            <p class="font-mono text-xs tracking-[0.2em] uppercase text-elf-blue dark:text-elf-blue mb-5">
-              International Standards for Information Modelling
-            </p>
+            <div class="flex items-center gap-3 mb-5">
+              <p class="font-mono text-xs tracking-[0.2em] uppercase text-elf-blue dark:text-elf-blue">
+                International Standards for Information Modelling
+              </p>
+              <span class="text-[0.6rem] font-mono font-semibold tracking-wider uppercase px-2 py-0.5 rounded-full border border-elf-blue/30 dark:border-elf-blue/40 text-elf-blue dark:text-elf-blue bg-elf-blue/5 dark:bg-elf-blue/10">501(c)(3)</span>
+            </div>
             <h1 class="text-4xl sm:text-5xl lg:text-[3.5rem] font-serif font-bold text-gray-900 dark:text-white leading-[1.15] tracking-tight">
               The language family<br />
               behind
@@ -266,6 +269,29 @@ const milestones = [
       </div>
     </section>
 
+    <!-- Supporting Organizations -->
+    <section class="py-16 bg-white dark:bg-navy">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <AnimatedSection>
+          <div class="text-center mb-12">
+            <p class="font-mono text-xs tracking-[0.2em] uppercase text-elf-blue dark:text-elf-blue mb-3">Heritage</p>
+            <h2 class="text-2xl font-serif font-bold text-gray-900 dark:text-white">Born from industry leaders</h2>
+            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 max-w-lg mx-auto">
+              The EXPRESS language originated from collaboration between major aerospace, manufacturing, and standards organizations.
+            </p>
+          </div>
+        </AnimatedSection>
+        <AnimatedSection>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-8 items-center justify-items-center">
+            <img src="/images/supporters/supporter-boeing.png" alt="Boeing" class="h-12 w-auto opacity-60 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-300 dark:invert dark:opacity-50 dark:hover:opacity-90" />
+            <img src="/images/supporters/supporter-md.png" alt="McDonnell Douglas" class="h-12 w-auto opacity-60 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-300 dark:invert dark:opacity-50 dark:hover:opacity-90" />
+            <img src="/images/supporters/supporter-ge.png" alt="General Electric" class="h-12 w-auto opacity-60 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-300 dark:invert dark:opacity-50 dark:hover:opacity-90" />
+            <img src="/images/supporters/supporter-nist.png" alt="NIST" class="h-12 w-auto opacity-60 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-300 dark:invert dark:opacity-50 dark:hover:opacity-90" />
+          </div>
+        </AnimatedSection>
+      </div>
+    </section>
+
     <!-- Latest News -->
     <section class="py-24 bg-white dark:bg-navy">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -367,8 +393,11 @@ const milestones = [
             We facilitate education, standardization, research, and promotion of the EXPRESS language family.
             Membership is open to organizations and individuals worldwide.
           </p>
-          <p class="text-sm text-blue-200/70 dark:text-gray-400 mb-8">
+          <p class="text-sm text-blue-200/70 dark:text-gray-400 mb-2">
             Founded by the original inventors of EXPRESS, including Douglas Schenck, Peter Wilson, and Allison Barnard Feeney.
+          </p>
+          <p class="text-sm text-blue-200/70 dark:text-gray-400 mb-8">
+            ELF is a US-registered 501(c)(3) public charity — your contributions are tax-deductible.
           </p>
           <div class="flex flex-wrap justify-center gap-3">
             <BaseButton to="/membership" size="lg">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14,9 +14,9 @@
   --color-navy-light: #2e2a2b;
   --color-slate-bg: #f8f9fb;
 
-  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
-  --font-logo: 'Montserrat', 'Inter', system-ui, -apple-system, sans-serif;
+  --font-sans: 'Fira Sans', system-ui, -apple-system, sans-serif;
+  --font-serif: 'Montserrat', 'Fira Sans', system-ui, -apple-system, sans-serif;
+  --font-logo: 'Montserrat', 'Fira Sans', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
 }
 


### PR DESCRIPTION
Addresses multiple open GitHub issues:

- **#35** — Add 501(c)(3) badge to homepage hero section and mention tax-deductible status in CTA
- **#4, #6, #9** — Enrich EXPRESS language page with new sections: building blocks, datatypes, entity attributes, supertypes/subtypes, constraints and rules, functions and procedures
- **#10** — Add supporting organizations section on homepage with logos (Boeing, McDonnell Douglas, GE, NIST)
- **#15** — Switch fonts from Inter/Source Serif 4 to Montserrat (headings/branding) and Fira Sans (body text)
- **#23** — Clean up Jekyll frontmatter from all content files (removed `layout:`, `html-class:`, `page-liquid` attributes)

Note: #12 (expresslangdoc) is a spec-level discussion, not website content — will close with comment.