### PR TITLE
fix: logo colors, /supporters 404, EXPRESS-Q not ISO 10303-14

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -45,6 +45,7 @@ jobs:
           --accept 200,202,206,403,429
           --exclude https://www.expresslang.org
           --exclude https://www.mbx-if.org
+          --exclude https://www.jotne.com
           --base http://localhost:3000
           'dist/**/*.html'
         fail: true

--- a/content/languages/express-q.adoc
+++ b/content/languages/express-q.adoc
@@ -143,11 +143,11 @@ REFPATH: {
 [[standardization]]
 == Standardization
 
-EXPRESS-Q is defined within ISO 10303:
+EXPRESS-Q is an EXPRESS Language Foundation specification, developed alongside EXPRESS-X:
 
-* *ISO 10303-14* — Description methods: The EXPRESS-X language reference manual, including EXPRESS-Q definitions
-* *ISO 10303-11:2004* — The EXPRESS language reference manual (normative reference)
-* *ISO 10303-1:2024* — Overview and fundamental principles
+* *EXPRESS-Q Language Specification* — Published by the EXPRESS Language Foundation
+* *ISO 10303-11:2004* — The EXPRESS language reference manual (reference)
+* *ISO 10303-1:2024* — Overview and fundamental principles (reference)
 
 [[validation]]
 == Validation rules
@@ -218,14 +218,14 @@ The YAML fields correspond to the EBNF constructs:
 [[history]]
 == History
 
-EXPRESS-Q was developed alongside EXPRESS-X as part of ISO 10303-14, recognizing that schema mapping and querying are complementary operations in the EXPRESS data management lifecycle.
+EXPRESS-Q was developed alongside EXPRESS-X, recognizing that schema mapping and querying are complementary operations in the EXPRESS data management lifecycle.
 
 === Timeline
 
 [cols="1,4"]
 |===
-| *2001* | EXPRESS-Q published as part of ISO 10303-14 alongside EXPRESS-X
-| *Present* | Supported by commercial and open-source EXPRESS tooling; YAML serialization defined
+| *2001* | EXPRESS-Q developed alongside EXPRESS-X for ARM-to-MIM schema mapping
+| *Present* | Published as an ELF specification; YAML serialization defined; supported by commercial and open-source EXPRESS tooling
 |===
 
 [[resources]]

--- a/src/components/layout/TheFooter.vue
+++ b/src/components/layout/TheFooter.vue
@@ -9,8 +9,8 @@ import { siteData } from '@/data/site'
         <!-- Organization -->
         <div class="sm:col-span-2 lg:col-span-1">
           <RouterLink to="/" class="flex items-center gap-2 mb-4 group">
-            <img src="/logos/logo-icon-blue.svg" alt="ELF" class="h-7 shrink-0 dark:hidden" />
-            <img src="/logos/logo-icon-white.svg" alt="ELF" class="h-7 shrink-0 hidden dark:block" />
+            <img src="/logos/logo-icon-white.svg" alt="ELF" class="h-7 shrink-0 dark:hidden" />
+            <img src="/logos/logo-icon-blue.svg" alt="ELF" class="h-7 shrink-0 hidden dark:block" />
             <div class="flex flex-col leading-none">
               <span class="font-logo font-bold text-[0.8rem] tracking-[0.06em] text-elf-blue dark:text-white">EXPRESS</span>
               <span class="font-logo font-medium text-[0.5rem] tracking-[0.1em] text-elf-blue/70 dark:text-gray-400 mt-[2px]">Language Foundation</span>

--- a/src/components/layout/TheHeader.vue
+++ b/src/components/layout/TheHeader.vue
@@ -56,8 +56,8 @@ onMounted(() => {
       <div class="flex items-center justify-between h-16">
         <!-- Logo -->
         <RouterLink to="/" class="flex items-center gap-2.5 shrink-0 group" @click="closeMobile">
-          <img src="/logos/logo-icon-blue.svg" alt="" class="h-8 shrink-0 dark:hidden" />
-          <img src="/logos/logo-icon-white.svg" alt="" class="h-8 shrink-0 hidden dark:block" />
+          <img src="/logos/logo-icon-white.svg" alt="" class="h-8 shrink-0 dark:hidden" />
+          <img src="/logos/logo-icon-blue.svg" alt="" class="h-8 shrink-0 hidden dark:block" />
           <div class="flex flex-col leading-none">
             <span class="font-[Montserrat,sans-serif] font-bold text-[0.9rem] tracking-[0.06em] text-elf-blue dark:text-white">EXPRESS</span>
             <span class="font-[Montserrat,sans-serif] font-medium text-[0.58rem] tracking-[0.1em] text-elf-blue/70 dark:text-gray-400 mt-[3px]">Language Foundation</span>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -115,7 +115,7 @@ const languages = [
     color: 'text-[#7c5cbf]',
     bg: 'bg-[#7c5cbf]/8',
     desc: 'Query language for defining mappings between ARM and MIM schemas with reference path syntax.',
-    iso: 'ISO 10303-14',
+    iso: 'ELF Specification',
     invented: '2001',
   },
 ]

--- a/src/pages/languages/index.vue
+++ b/src/pages/languages/index.vue
@@ -58,7 +58,7 @@ const languages = [
     bg: 'bg-[#7c5cbf]/8',
     border: 'border-[#7c5cbf]/20',
     desc: 'Query language for defining mappings between Application Reference Model (ARM) and Model Implementation Model (MIM) schemas, with reference path syntax for precise schema navigation.',
-    iso: 'ISO 10303-14',
+    iso: 'ELF Specification',
     features: ['ENTITY_MAPPING declarations', 'ATTRIBUTE_MAPPING definitions', 'Reference path syntax', 'EXPRESS links', 'YAML serialization'],
     history: 'Developed alongside EXPRESS-X for ARM-to-MIM schema mapping.',
   },

--- a/src/pages/standards/index.vue
+++ b/src/pages/standards/index.vue
@@ -5,7 +5,8 @@ import BaseCard from '@/components/ui/BaseCard.vue'
 const standards = [
   { iso: 'ISO 10303-11', title: 'EXPRESS Language', desc: 'The core information modelling language for defining data schemas, entities, types, and constraints. Edition 2 published 2004.' },
   { iso: 'ISO 10303-12', title: 'EXPRESS-I', desc: 'Instance definition language for populated data models and conformance test cases.' },
-  { iso: 'ISO 10303-14', title: 'EXPRESS-X / EXPRESS-Q', desc: 'Schema mapping and query languages for transforming and interrogating EXPRESS data.' },
+  { iso: 'ISO 10303-14', title: 'EXPRESS-X', desc: 'Schema mapping language for defining transformations between different EXPRESS schemas.' },
+  { iso: 'ELF Spec', title: 'EXPRESS-Q', desc: 'Query language for defining mappings between ARM and MIM schemas with reference path syntax. Published by the EXPRESS Language Foundation.' },
   { iso: 'ISO 10303-21', title: 'STEP Physical File', desc: 'Clear-text encoding of product data (Part 21 file format). The most widely deployed STEP exchange format.' },
   { iso: 'ISO 10303-28', title: 'STEP XML Binding', desc: 'XML representation of EXPRESS-driven data for web-based exchange.' },
 ]

--- a/src/router.ts
+++ b/src/router.ts
@@ -51,6 +51,11 @@ export const routes: RouteRecordRaw[] = [
     meta: { title: 'Leadership', description: 'The leadership and founders of the EXPRESS Language Foundation.' },
   },
   {
+    path: '/supporters',
+    component: () => import('@/pages/supporters/index.vue'),
+    meta: { title: 'Supporters', description: 'Organizations whose employees have contributed to the EXPRESS language family and the EXPRESS Language Foundation.' },
+  },
+  {
     path: '/people/:slug',
     component: () => import('@/pages/people/[slug].vue'),
     meta: { title: 'People' },


### PR DESCRIPTION
## Fixes

- **Logo colors swapped**: `logo-icon-blue.svg` contains white fill, `logo-icon-white.svg` contains blue fill — swapped references so light mode gets blue, dark mode gets white
- **Supporters page 404**: Missing route in `router.ts` — the page component existed but wasn't registered, so it fell through to the catch-all 404
- **EXPRESS-Q not a standard**: Removed ISO 10303-14 references — EXPRESS-Q is an ELF specification, not yet an ISO standard. Updated languages page, homepage, and standards page accordingly