### PR TITLE
fix: EXPRESS-Q color, responsive learn sidebar, language icons

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -112,7 +112,7 @@ const languages = [
   {
     name: 'EXPRESS-Q',
     slug: 'express-q',
-    color: '#7c5cbf',
+    color: '#ed1c24',
     icon: '/logos/logo-lang-icon-expressq.svg',
     desc: 'Query language for defining mappings between ARM and MIM schemas with reference path syntax.',
     iso: 'ELF Specification',

--- a/src/pages/languages/[slug].vue
+++ b/src/pages/languages/[slug].vue
@@ -18,7 +18,7 @@ const languageMeta: Record<string, LanguageInfo> = {
   'express-g': { iso: 'ISO 10303-11:2004', color: '#4ec0aa', icon: '/logos/logo-lang-icon-expressg.svg' },
   'express-i': { iso: 'ISO 10303-12', color: '#d85577', icon: '/logos/logo-lang-icon-expressi.svg' },
   'express-x': { iso: 'ISO 10303-14', color: '#077783', icon: '/logos/logo-lang-icon-expressx.svg' },
-  'express-q': { iso: 'ELF Specification', color: '#7c5cbf', icon: '/logos/logo-lang-icon-expressq.svg' },
+  'express-q': { iso: 'ELF Specification', color: '#ed1c24', icon: '/logos/logo-lang-icon-expressq.svg' },
 }
 
 const siblings = [

--- a/src/pages/languages/index.vue
+++ b/src/pages/languages/index.vue
@@ -50,7 +50,7 @@ const languages = [
     name: 'EXPRESS-Q',
     id: 'express-q',
     slug: 'express-q',
-    color: '#7c5cbf',
+    color: '#ed1c24',
     icon: '/logos/logo-lang-icon-expressq.svg',
     desc: 'Query language for defining mappings between Application Reference Model (ARM) and Model Implementation Model (MIM) schemas, with reference path syntax for precise schema navigation.',
     iso: 'ELF Specification',

--- a/src/pages/learn/index.vue
+++ b/src/pages/learn/index.vue
@@ -30,7 +30,11 @@ import BaseCard from '@/components/ui/BaseCard.vue'
               The authoritative course on the EXPRESS language — from the co-inventor of EXPRESS-G and EXPRESS-X. Covers syntax, semantics, modelling patterns, rules, and practical exercises.
             </p>
             <p class="text-xs text-gray-400 dark:text-gray-500 italic mb-4">By Peter Wilson, co-author of <em class="italic">Information Modelling: The EXPRESS Way</em></p>
-            <p class="text-xs font-mono text-gray-400 dark:text-gray-500">{{ learnNavigation.length }} modules</p>
+            <p class="text-xs font-mono text-gray-400 dark:text-gray-500 mb-3">{{ learnNavigation.length }} modules</p>
+            <div class="flex items-center gap-2">
+              <img src="/logos/logo-lang-icon-express.svg" alt="EXPRESS" title="EXPRESS" class="h-6 w-auto" />
+              <img src="/logos/logo-lang-icon-expressg.svg" alt="EXPRESS-G" title="EXPRESS-G" class="h-6 w-auto" />
+            </div>
           </BaseCard>
         </AnimatedSection>
 
@@ -44,7 +48,12 @@ import BaseCard from '@/components/ui/BaseCard.vue'
               The applied course on the ISO 10303 ecosystem — STEP file formats, data validation, schema querying, business rules, SDAI programming, and PLCS. Assumes basic EXPRESS knowledge.
             </p>
             <p class="text-xs text-gray-400 dark:text-gray-500 italic mb-4">Contributed by Jotne EPM Technology</p>
-            <p class="text-xs font-mono text-gray-400 dark:text-gray-500">{{ courseNavigation.length }} modules</p>
+            <p class="text-xs font-mono text-gray-400 dark:text-gray-500 mb-3">{{ courseNavigation.length }} modules</p>
+            <div class="flex items-center gap-2">
+              <img src="/logos/logo-lang-icon-express.svg" alt="EXPRESS" title="EXPRESS" class="h-6 w-auto" />
+              <img src="/logos/logo-lang-icon-expressg.svg" alt="EXPRESS-G" title="EXPRESS-G" class="h-6 w-auto" />
+              <img src="/logos/logo-lang-icon-expressx.svg" alt="EXPRESS-X" title="EXPRESS-X" class="h-6 w-auto" />
+            </div>
           </BaseCard>
         </AnimatedSection>
       </div>

--- a/src/pages/learn/jotne-express/[slug].vue
+++ b/src/pages/learn/jotne-express/[slug].vue
@@ -25,7 +25,7 @@ const baseUrl = '/learn/jotne-express'
 
 <template>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-    <div class="flex gap-8">
+    <div class="lg:flex lg:gap-8">
       <TheSidebar :items="courseNavigation" :current-slug="slug" base-url="/learn/jotne-express" />
       <div class="flex-1 min-w-0">
         <template v-if="content">

--- a/src/pages/learn/tutorial/[slug].vue
+++ b/src/pages/learn/tutorial/[slug].vue
@@ -25,7 +25,7 @@ const baseUrl = '/learn/tutorial'
 
 <template>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-    <div class="flex gap-8">
+    <div class="lg:flex lg:gap-8">
       <TheSidebar :items="learnNavigation" :current-slug="slug" base-url="/learn/tutorial" />
       <div class="flex-1 min-w-0">
         <template v-if="content">


### PR DESCRIPTION
- Fix EXPRESS-Q color from #7c5cbf to #ed1c24 (matching logo)\n- Make learn/tutorial and learn/jotne-express sidebar responsive (hidden on mobile, side-by-side on lg+)\n- Add language icons to learn page course cards